### PR TITLE
update:#38 마커 클릭시 해당 메모 렌더

### DIFF
--- a/src/components/features/DetailPlanMap.jsx
+++ b/src/components/features/DetailPlanMap.jsx
@@ -1,6 +1,7 @@
 import { useRef } from 'react';
 import { useNaverMapInitializer, useNaverMapObject } from '../../lib/hooks/useDetailMapcreate';
 import { markerFile, planMapFile, polylineFile } from '../../constants/naverMap';
+import { makeConfirmedIcon } from '../../lib/utils/makeMarkerIcon';
 
 const DetailPlanMap = ({ detailPlans, setMarkerMemo }) => {
   const map = useNaverMapObject(); // 생성된 map mapRef에 전달
@@ -28,20 +29,8 @@ const DetailPlanMap = ({ detailPlans, setMarkerMemo }) => {
           position: coord,
           value: plan.plan_memo,
           icon: {
-            content: `<div style="
-                    background-color: white;
-                    border: 2px solid black;
-                    padding: 6px;
-                    border-radius: 50%;
-                    font-weight: bold;
-                    font-size: 14px;
-                    width: 30px;
-                    height: 30px;
-                    display: flex;
-                    justify-content: center;
-                    align-items: center;
-                  ">${index + 1}</div>`,
-            anchor: new naver.maps.Point(markerFile.ANCHORPOINT, markerFile.ANCHORPOINT)
+            content: makeConfirmedIcon(index + 1),
+            anchor: new naver.maps.Point(markerFile.ANCHORPOINT_X, markerFile.ANCHORPOINT_Y)
           }
         })
       };

--- a/src/constants/naverMap.js
+++ b/src/constants/naverMap.js
@@ -12,7 +12,6 @@ export const planMapFile = {
 };
 
 export const markerFile = {
-  ANCHORPOINT: 15,
   ZOOM: 3,
   CLICK: 'click',
   ANCHORPOINT_X: 15,

--- a/src/pages/DetailPlanPage.jsx
+++ b/src/pages/DetailPlanPage.jsx
@@ -9,6 +9,7 @@ const DetailPlanPage = () => {
   const { id } = useParams();
   const [plan, setPlan] = useState({});
   const [detailPlans, setDetailPlans] = useState([]);
+  const [markerMemo, setMarkerMemo] = useState('');
   let day = 0;
 
   // params에 해당하는 plan 호출
@@ -35,7 +36,12 @@ const DetailPlanPage = () => {
   return (
     <div>
       <h2>{plan.title}</h2>
-      {detailPlans.length > 0 ? <DetailPlanMap detailPlans={detailPlans} /> : `지도 정보를 불러오고 있습니다.`}
+      {detailPlans.length > 0 ? (
+        <DetailPlanMap detailPlans={detailPlans} setMarkerMemo={setMarkerMemo} />
+      ) : (
+        `지도 정보를 불러오고 있습니다.`
+      )}
+      <div>{markerMemo}</div>
       <div>
         <div>
           <ul>


### PR DESCRIPTION
- 제목 : feat(38): detail plan page에서 맵에 있는 마커 클릭시 해당 메모 렌더

<br/>

#38 

  <br/>

## 🔎 작업 내용

- 이전에는 마커 클릭하면 지도만 이동 -> 마커에 해당하는 메모 렌더
  <br/>

## 3분

<br/>

## 미리보기

https://github.com/user-attachments/assets/78f01c0d-b7bf-4c7d-a073-d3c410bbce34



<br/>
