### PR TITLE
fix: 카드 내에서 시간 순으로 계획 정렬

### DIFF
--- a/src/lib/utils/processPlansData.js
+++ b/src/lib/utils/processPlansData.js
@@ -2,15 +2,19 @@ const processPlansData = (detail_plans) => {
   const datedPlansObj = detail_plans.reduce((acc, cur) => {
     const PLAN_DATE = cur.plan_date;
     const PLAN_MEMO = cur.plan_memo;
+    const PLAN_TIME = cur.plan_time;
+
     acc[PLAN_DATE] = acc[PLAN_DATE] || [];
-    acc[PLAN_DATE].push(PLAN_MEMO);
+    acc[PLAN_DATE].push({ memo: PLAN_MEMO, time: PLAN_TIME });
     return acc;
   }, {});
 
-  const datedPlansArr = Object.entries(datedPlansObj).map(([date, memo]) => {
-    return { date: date, memo: memo };
+  const datedPlansArr = Object.entries(datedPlansObj).map(([date, plans]) => {
+    const sortedPlans = plans.sort((a, b) => {
+      return a.time.localeCompare(b.time);
+    });
+    return { date: date, memo: sortedPlans.map((plan) => plan.memo) };
   });
-
   return datedPlansArr;
 };
 


### PR DESCRIPTION
## 🔎 작업 내용

- 카드내에서 계획 시간 순 정렬
  <br/>

## 리뷰 예상 시간
- 30초
<br/>

## 미리보기

<br/>
